### PR TITLE
fix: remove convert for AbstractStaticString{N} which causes invalidation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,10 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1.6'
-          - '1.7'
-          - '1.8'
+          - '1'
+          - 'lts'
+          - 'pre'
           - 'nightly'
         os:
           - ubuntu-latest
@@ -29,15 +28,15 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v5
         with:
           files: lcov.info
   docs:
@@ -47,7 +46,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - uses: julia-actions/julia-buildpkg@v1

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 
 [compat]
 Compat = "3, 4"
-julia = "1"
+julia = "1.10"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -20,9 +20,6 @@ function Base.String(nstring::AbstractStaticString{N}) where {N}
     b = Base.StringVector(N)
     return String(b .= data(nstring))
 end
-function Base.convert(::Type{String}, nstring::AbstractStaticString{N}) where N
-    return String(nstring)
-end
 
 # Convert [Abstract]String to AbstractStaticStrings
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -14,10 +14,10 @@ function Base.read(io::IO, ::Type{CStaticString}; sizehint=255)
     end
     return CStaticString((buffer...,))
 end
-function Base.write(io::IO, ass::T) where {N, T<: AbstractStaticString{N}}
-    sum(codeunits(ass)) do byte
-        write(io, byte)
-    end
+
+@static if isdefined(Base, :AnnotatedIOBuffer)
+    Base.write(io::Base.AnnotatedIOBuffer, cs::CStaticString{N}) where N =
+        invoke(write, Tuple{IO, CStaticString{N}}, io, cs)
 end
 function Base.write(io::IO, cs::CStaticString{N}) where N
     foreach(codeunits(cs)) do byte

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,10 +11,6 @@ using Test
     include("io.jl")
     include("ambiguities.jl")
     include("AbstractStaticString.jl")
-    @static if VERSION ≥ v"1.6"
-        include("inlinestrings.jl")
-    end
-    @static if VERSION ≥ v"1.7"
-        include("statictools.jl")
-    end
+    include("inlinestrings.jl")
+    include("statictools.jl")
 end


### PR DESCRIPTION
since in `Base`, we already have:
```julia
convert(::Type{T}, s::AbstractString) where {T<:AbstractString} = T(s)::T
```

remove the redundant definition to avoid invalidation.